### PR TITLE
Fixed bug with lambda-query (Min, Max, Average, Sum)

### DIFF
--- a/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Analyzer.cs
+++ b/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Analyzer.cs
@@ -604,6 +604,11 @@ namespace DbLinq.Data.Linq.Sugar.Implementation
                     else
                         projectionOperand = Analyze(groupOperand0.GroupedExpression, builderContext);
                 }
+                else if ((operand0 is TableExpression) && parameters.Count > 1 && (specialExpressionType == SpecialExpressionType.Min ||
+                    specialExpressionType == SpecialExpressionType.Max || specialExpressionType == SpecialExpressionType.Average))
+                {
+                    projectionOperand = Analyze(parameters[1], parameters[0], builderContext);
+                }
                 else
                 {
                     projectionOperand = operand0;

--- a/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Analyzer.cs
+++ b/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Analyzer.cs
@@ -604,8 +604,9 @@ namespace DbLinq.Data.Linq.Sugar.Implementation
                     else
                         projectionOperand = Analyze(groupOperand0.GroupedExpression, builderContext);
                 }
-                else if ((operand0 is TableExpression) && parameters.Count > 1 && (specialExpressionType == SpecialExpressionType.Min ||
-                    specialExpressionType == SpecialExpressionType.Max || specialExpressionType == SpecialExpressionType.Average))
+                else if ((operand0 is TableExpression) && parameters.Count > 1 && 
+                    (specialExpressionType == SpecialExpressionType.Min || specialExpressionType == SpecialExpressionType.Max ||
+                    specialExpressionType == SpecialExpressionType.Average || specialExpressionType == SpecialExpressionType.Sum))
                 {
                     projectionOperand = Analyze(parameters[1], parameters[0], builderContext);
                 }


### PR DESCRIPTION
int maxValue = context.MyTable.Max(x => x.Value);

Such query produced InvalidCastException. The same for Min, Average, Sum.

Fixed.