### PR TITLE
Added: connection disposing for connection-string based context.

### DIFF
--- a/src/DbLinq/Data/Linq/DataContext.cs
+++ b/src/DbLinq/Data/Linq/DataContext.cs
@@ -1075,7 +1075,7 @@ namespace DbLinq.Data.Linq
 			//We own the instance of MemberModificationHandler - we must unregister listeners of entities we attached to
 			MemberModificationHandler.UnregisterAll();
 
-            if (shouldConnectionBeDisposed)
+            if (shouldConnectionBeDisposed && DatabaseContext.Connection != null)
             {
                 DatabaseContext.Connection.Dispose();
             }

--- a/src/DbLinq/Data/Linq/DataContext.cs
+++ b/src/DbLinq/Data/Linq/DataContext.cs
@@ -83,6 +83,7 @@ namespace DbLinq.Data.Linq
         private bool deferredLoadingEnabled = true;
 
         private bool queryCacheEnabled = false;
+        private bool shouldConnectionBeDisposed = false;
 
         /// <summary>
         /// Disable the QueryCache: this is surely good for rarely used Select, since preparing
@@ -178,6 +179,8 @@ namespace DbLinq.Data.Linq
 
             IDbConnection dbConnection = ivendor.CreateDbConnection(fileOrServerOrConnection);
             Init(new DatabaseContext(dbConnection), mapping, ivendor);
+            shouldConnectionBeDisposed = true;
+
             Profiler.At("END DataContext(string, MappingSource)");
         }
 
@@ -199,6 +202,7 @@ namespace DbLinq.Data.Linq
 
             IDbConnection dbConnection = ivendor.CreateDbConnection(connectionString);
             Init(new DatabaseContext(dbConnection), null, ivendor);
+            shouldConnectionBeDisposed = true;
 
             Profiler.At("END DataContext(string)");
         }
@@ -1070,6 +1074,11 @@ namespace DbLinq.Data.Linq
 
 			//We own the instance of MemberModificationHandler - we must unregister listeners of entities we attached to
 			MemberModificationHandler.UnregisterAll();
+
+            if (shouldConnectionBeDisposed)
+            {
+                DatabaseContext.Connection.Dispose();
+            }
         }
 
         [DbLinqToDo]

--- a/src/DbLinq/Data/Linq/DataContext.cs
+++ b/src/DbLinq/Data/Linq/DataContext.cs
@@ -179,6 +179,9 @@ namespace DbLinq.Data.Linq
 
             IDbConnection dbConnection = ivendor.CreateDbConnection(fileOrServerOrConnection);
             Init(new DatabaseContext(dbConnection), mapping, ivendor);
+
+            // We just created the connection instance and we have to tell
+            // that it should dispose the connection when the context is disposed.
             shouldConnectionBeDisposed = true;
 
             Profiler.At("END DataContext(string, MappingSource)");
@@ -202,6 +205,9 @@ namespace DbLinq.Data.Linq
 
             IDbConnection dbConnection = ivendor.CreateDbConnection(connectionString);
             Init(new DatabaseContext(dbConnection), null, ivendor);
+
+            // We just created the connection instance and we have to tell
+            // that it should dispose the connection when the context is disposed.
             shouldConnectionBeDisposed = true;
 
             Profiler.At("END DataContext(string)");
@@ -1075,9 +1081,12 @@ namespace DbLinq.Data.Linq
 			//We own the instance of MemberModificationHandler - we must unregister listeners of entities we attached to
 			MemberModificationHandler.UnregisterAll();
 
+            // If we created the connection, we need to dispose it even if the user explicitly
+            // opened it using the Connection property on the context.
             if (shouldConnectionBeDisposed && DatabaseContext.Connection != null)
             {
                 DatabaseContext.Connection.Dispose();
+                DatabaseContext.Connection = null;
             }
         }
 


### PR DESCRIPTION
There is a two ways of DataContext creation: by IDbConnection and by connection string. In the second case, IDbConnection is created inside DataContext. I think, it should be disposed on DataContext disposing, otherwise connection is stays on; connection pool can't use it over and has to create a new one with next DataContext creation. I discovered it when I saw huge amounts of "postgres" porocesses (PostgreSQL creates a new process on each connection).

I added shouldConnectionBeDisposed property (for DataContext created by connection string). If it's set to TRUE, connection is disposed on DataContext disposing.
It solved problem with large amounts "postgres" porocesses.