### PR TITLE
Added IQueryProvider interface for providing access to DataContext

### DIFF
--- a/src/DbLinq/Data/Linq/Implementation/IQueryProvider.cs
+++ b/src/DbLinq/Data/Linq/Implementation/IQueryProvider.cs
@@ -1,8 +1,5 @@
-﻿#if MONO_STRICT
+﻿#if !MONO_STRICT
 using System.Data.Linq;
-#else
-using DbLinq.Data.Linq;
-#endif
 
 namespace DbLinq.Data.Linq.Implementation
 {
@@ -14,3 +11,5 @@ namespace DbLinq.Data.Linq.Implementation
         DataContext Context { get; }
     }
 }
+
+#endif

--- a/src/DbLinq/Data/Linq/Implementation/IQueryProvider.cs
+++ b/src/DbLinq/Data/Linq/Implementation/IQueryProvider.cs
@@ -1,0 +1,16 @@
+﻿#if MONO_STRICT
+using System.Data.Linq;
+#else
+using DbLinq.Data.Linq;
+#endif
+
+namespace DbLinq.Data.Linq.Implementation
+{
+    /// <summary>
+    /// Interface of QueryProvider
+    /// </summary>
+    public interface IQueryProvider<T>
+    {
+        DataContext Context { get; }
+    }
+}

--- a/src/DbLinq/Data/Linq/Implementation/QueryProvider.cs
+++ b/src/DbLinq/Data/Linq/Implementation/QueryProvider.cs
@@ -69,7 +69,10 @@ namespace DbLinq.Data.Linq.Implementation
     /// QueryProvider, generic version
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class QueryProvider<T> : QueryProvider, IQueryProvider, IQueryable<T>, IOrderedQueryable<T>, IQueryProvider<T>
+    internal class QueryProvider<T> : QueryProvider, IQueryProvider, IQueryable<T>, IOrderedQueryable<T>
+#if !MONO_STRICT
+        , IQueryProvider<T>
+#endif
     {
         /// <summary>
         /// Holder current datancontext

--- a/src/DbLinq/Data/Linq/Implementation/QueryProvider.cs
+++ b/src/DbLinq/Data/Linq/Implementation/QueryProvider.cs
@@ -69,12 +69,18 @@ namespace DbLinq.Data.Linq.Implementation
     /// QueryProvider, generic version
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class QueryProvider<T> : QueryProvider, IQueryProvider, IQueryable<T>, IOrderedQueryable<T>
+    internal class QueryProvider<T> : QueryProvider, IQueryProvider, IQueryable<T>, IOrderedQueryable<T>, IQueryProvider<T>
     {
         /// <summary>
         /// Holder current datancontext
         /// </summary>
         protected readonly DataContext _dataContext;
+
+        /// <summary> Current dataContext </summary>
+        public DataContext Context
+        {
+            get { return _dataContext; }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryProvider&lt;T&gt;"/> class.

--- a/src/DbLinq/DbLinq.csproj
+++ b/src/DbLinq/DbLinq.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Data\Linq\Implementation\EntityTrack.cs" />
     <Compile Include="Data\Linq\Implementation\EntityState.cs" />
     <Compile Include="Data\Linq\Implementation\EntityTracker.cs" />
+    <Compile Include="Data\Linq\Implementation\IQueryProvider.cs" />
     <Compile Include="Data\Linq\Implementation\VendorProvider.cs" />
     <Compile Include="Data\Linq\ITable.Extended.cs" />
     <Compile Include="Data\Linq\DataContext.cs" />

--- a/src/DbLinq/System.Data.Linq.csproj
+++ b/src/DbLinq/System.Data.Linq.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Data\Linq\Implementation\EntityTrack.cs" />
     <Compile Include="Data\Linq\Implementation\EntityTracker.cs" />
     <Compile Include="Data\Linq\Implementation\IEntityTracker.cs" />
+    <Compile Include="Data\Linq\Implementation\IQueryProvider.cs" />
     <Compile Include="Data\Linq\Implementation\MemberModificationHandler.cs" />
     <Compile Include="Data\Linq\Implementation\QueryProvider.cs" />
     <Compile Include="Data\Linq\Implementation\VendorProvider.cs" />


### PR DESCRIPTION
This allowes to use both DbLinq and Dapper-dot-net projects. Dapper is incredible fast database object mapper. But it doesn't support lambda expressions, user should write regular text SQL-queries. I found a way, how to use LINQ-queries with Dapper - via DbLinq and Context.GetCommand method.

So, if we write in application such helper

    public static List<T> DapperExecute<T>(this IQueryable<T> query)
    {
        var provider = query as IQueryProvider<T>;
        var command = provider.Context.GetCommand(query);

        var reader = command.ExecuteReader();
        var ret = reader.Parse<T>().ToList();
        return ret;
    }

we can write such queries:

    var trends = context.Trend.Where(x => x.TagID == tagId && x.DateTime >= dtMin).DapperExecute();

It works much faster than ordinary Linq-to-SQL query. And the more records in result, the more speed difference. I call it "Linq-to-Dapper"

By the way, In earlier Dapper-dot-net versions you coundn't use DbCommand with parameters. I wrote an issue to their github project and tried to implement a needed method. https://github.com/StackExchange/dapper-dot-net/issues/270
Marc Gravell, one of the project leaders, said he likes my idea, but he'll think about best solution. And then he has done it: https://github.com/StackExchange/dapper-dot-net/commit/874731600e01a9dbf271c09f93a238bf7979ac6c

The second advantage of using Dapper-dot-net with DbLinq is you can use table classes generated by DbMetal for mapping (Dapper just maps to objects of prepared classes, it doesn't genetrate anything).

Now then. I like to use DbLinq and Dapper both. If I need to select one or several records, I use regular DbLinq queries. But for large result sets I use Linq-to-Dapper. Thus, we have a powerful framework performs several dozen times faster than EntityFramework!