### PR TITLE
Added feature: DataContext class naming mode.

### DIFF
--- a/src/DbLinq/Schema/INameFormatter.cs
+++ b/src/DbLinq/Schema/INameFormatter.cs
@@ -41,7 +41,11 @@ namespace DbLinq.Schema
         /// <param name="extraction">The extraction.</param>
         /// <param name="nameFormat">The name format.</param>
         /// <returns></returns>
-        SchemaName GetSchemaName(string dbName, WordsExtraction extraction, NameFormat nameFormat);
+        SchemaName GetSchemaName(string dbName, WordsExtraction extraction, NameFormat nameFormat
+#if !MONO_STRICT
+            , string contextClassNamePostfix
+#endif
+            );
         /// <summary>
         /// Gets the name of the procedure.
         /// </summary>

--- a/src/DbLinq/Schema/Implementation/NameFormatter.cs
+++ b/src/DbLinq/Schema/Implementation/NameFormatter.cs
@@ -337,12 +337,19 @@ namespace DbLinq.Schema.Implementation
         /// <param name="extraction">The extraction.</param>
         /// <param name="nameFormat">The name format.</param>
         /// <returns></returns>
-        public SchemaName GetSchemaName(string dbName, WordsExtraction extraction, NameFormat nameFormat)
+        public SchemaName GetSchemaName(string dbName, WordsExtraction extraction, NameFormat nameFormat
+#if !MONO_STRICT
+            , string contextClassNamePostfix
+#endif
+            )
         {
             var words = GetLanguageWords(nameFormat.Culture);
             var schemaName = new SchemaName { DbName = dbName };
             schemaName.NameWords = ExtractWords(words, dbName, extraction);
             schemaName.ClassName = Format(words, schemaName.NameWords, nameFormat.Case, Singularization.DontChange);
+#if !MONO_STRICT
+            schemaName.ClassName += contextClassNamePostfix;
+#endif
             return schemaName;
         }
 

--- a/src/DbLinq/Vendor/ISchemaLoader.cs
+++ b/src/DbLinq/Vendor/ISchemaLoader.cs
@@ -61,6 +61,10 @@ namespace DbLinq.Vendor
         /// <param name="entityNamespace"></param>
         /// <returns></returns>
         Database Load(string databaseName, INameAliases nameAliases, NameFormat nameFormat,
-            bool loadStoredProcedures, string contextNamespace, string entityNamespace);
+            bool loadStoredProcedures, string contextNamespace, string entityNamespace
+#if !MONO_STRICT
+            , string contextNameMode
+#endif
+            );
     }
 }

--- a/src/DbMetal/Generator/Implementation/Processor.cs
+++ b/src/DbMetal/Generator/Implementation/Processor.cs
@@ -246,7 +246,11 @@ namespace DbMetal.Generator.Implementation
                 parameters.Write(">>> Reading schema from {0} database", schemaLoader.Vendor.VendorName);
                 dbSchema = schemaLoader.Load(parameters.Database, nameAliases,
                     new NameFormat(parameters.Pluralize, GetCase(parameters), new CultureInfo(parameters.Culture)),
-                    parameters.Sprocs, parameters.Namespace, parameters.Namespace);
+                    parameters.Sprocs, parameters.Namespace, parameters.Namespace
+#if !MONO_STRICT
+                    , parameters.ContextNameMode.ToLower()
+#endif
+                    );
                 dbSchema.Provider = parameters.Provider;
                 dbSchema.Tables.Sort(new LambdaComparer<Table>((x, y) => (x.Type.Name.CompareTo(y.Type.Name))));
                 foreach (var table in dbSchema.Tables)

--- a/src/DbMetal/Parameters.cs
+++ b/src/DbMetal/Parameters.cs
@@ -195,6 +195,11 @@ namespace DbMetal
         /// </summary>
         public IList<string> Extra = new List<string>();
 
+        /// <summary>
+        /// DB-context class naming mode
+        /// </summary>
+        public string ContextNameMode { get; set; }
+
         TextWriter log;
         public TextWriter Log
         {
@@ -213,6 +218,7 @@ namespace DbMetal
             MemberAttributes = new List<string>();
             GenerateTimestamps = true;
             EntityInterfaces = new []{ "INotifyPropertyChanging", "INotifyPropertyChanged" };
+            ContextNameMode = "wordextract";
         }
 
         public void Parse(IList<string> args)
@@ -319,7 +325,11 @@ namespace DbMetal
                   v => Debug = v != null },
                 { "h|?|help",
                   "Show this help",
-                  v => Help = v != null }
+                  v => Help = v != null },
+                { "context-name=",
+                  "DB-context class naming mode " + 
+                  "(default: wordextract; may be: wordextract+context, wordcase, wordcase+context)",
+                  v => ContextNameMode = v ?? "wordextract" },
             };
 
             Extra = Options.Parse(args);


### PR DESCRIPTION
In DBLinq class name of generated DataContext is created by word extraction of database name. E.g. for database called 'furniturestore' class 'FurnitureStore' is generated.

It's not always good:
1. It isn't clear from the class name that it is a DataContext.
2. Sometimes database may be called as company name. It can produce wrong class name. E.g. once I worked with company "Oris" and database named "oris". A class named "OrIs" was generated.

That's why I offer to introduce several modes of generated DataContext naming (examples for 'oris_data' database are given)
-wordextract (default, as older DBLinq).  "OrIsData"
-wordextract+context (as prev., with 'Context' word appending)  "OrIsDataContext"
-wordcase (database name is divided only by separator symbols)  "OrisData"
-wordcase+context (as prev., with 'Context' word appending)  "OrisDataContext"

Note that if this option isn't specified, default mode is used, as earlier DBLinq versions. So, users who don't needed this feature, they can use same DBMetal commands and get the same results as before