### PR TITLE
ExecuteQuery improvements

### DIFF
--- a/src/DbLinq/Data/Linq/DataContext.cs
+++ b/src/DbLinq/Data/Linq/DataContext.cs
@@ -1024,6 +1024,19 @@ namespace DbLinq.Data.Linq
             return QueryRunner.ExecuteSelect(elementType, directQuery, parameters);
         }
 
+#if !MONO_STRICT
+        /// <summary>
+        /// Execute raw SQL query and return primitive object
+        /// </summary>
+        public IEnumerable<TResult> ExecuteQueryPrimitive<TResult>(string query, params object[] parameters)
+        {
+            if (query == null)
+                throw new ArgumentNullException("query");
+
+            return ExecuteQuery<ObjectWrapper>(query, parameters).Select(x => (TResult)x.Value);
+        }
+#endif
+
         /// <summary>
         /// Gets or sets the load options
         /// </summary>

--- a/src/DbLinq/Data/Linq/ObjectWrapper.cs
+++ b/src/DbLinq/Data/Linq/ObjectWrapper.cs
@@ -1,0 +1,7 @@
+﻿namespace DbLinq.Data.Linq
+{
+    public class ObjectWrapper
+    {
+        public object Value { get; set; }
+    }
+}

--- a/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Registrar.cs
+++ b/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Registrar.cs
@@ -427,6 +427,11 @@ namespace DbLinq.Data.Linq.Sugar.Implementation
                     memberInfo = tableType.GetSingleMember(parameter, BindingFlags.Public | BindingFlags.NonPublic
                                                                       | BindingFlags.Instance | BindingFlags.IgnoreCase);
                 }
+                if (memberInfo == null && parameter.Contains('_'))
+                {
+                    memberInfo = tableType.GetSingleMember(parameter.Replace("_", ""), BindingFlags.Public | BindingFlags.NonPublic
+                                                                      | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                }
                 // TODO real error
                 if (memberInfo == null)
                     throw new ArgumentException(string.Format("Invalid column '{0}'", parameter));

--- a/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Registrar.cs
+++ b/src/DbLinq/Data/Linq/Sugar/Implementation/ExpressionDispatcher.Registrar.cs
@@ -427,11 +427,13 @@ namespace DbLinq.Data.Linq.Sugar.Implementation
                     memberInfo = tableType.GetSingleMember(parameter, BindingFlags.Public | BindingFlags.NonPublic
                                                                       | BindingFlags.Instance | BindingFlags.IgnoreCase);
                 }
+#if !MONO_STRICT
                 if (memberInfo == null && parameter.Contains('_'))
                 {
                     memberInfo = tableType.GetSingleMember(parameter.Replace("_", ""), BindingFlags.Public | BindingFlags.NonPublic
                                                                       | BindingFlags.Instance | BindingFlags.IgnoreCase);
                 }
+#endif
                 // TODO real error
                 if (memberInfo == null)
                     throw new ArgumentException(string.Format("Invalid column '{0}'", parameter));

--- a/src/DbLinq/DbLinq.csproj
+++ b/src/DbLinq/DbLinq.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Data\Linq\Mapping\LambdaMetaAccessor.cs" />
     <Compile Include="Data\Linq\Mapping\MappingContext.cs" />
     <Compile Include="Data\Linq\Mapping\XmlMappingSource.cs" />
+    <Compile Include="Data\Linq\ObjectWrapper.cs" />
     <Compile Include="Data\Linq\SqlClient\FirebirdProvider.cs" />
     <Compile Include="Data\Linq\SqlClient\Sql2005Provider.cs" />
     <Compile Include="Data\Linq\SqlClient\Sql2000Provider.cs" />


### PR DESCRIPTION
1.
DBLinq allowes to execute any query and map result into collection of any class.

```
class AccountsInfo
{
    public DateTime MaxBirth { get; set; }
    public long Count { get; set; }
}

string query = "SELECT MAX(birth) AS maxbirth, COUNT(*) FROM account";
var result = context.ExecuteQuery<AccountsInfo>(query).First();
```

But if you want to get simple type, not class,

```
query = "SELECT COUNT(*) FROM account";
long count = context.ExecuteQuery<long>(query).First();
```

You get a compiler error, because type of TResult must be a class.

To solve this, I added method ExecuteQueryPrimitive, which can be used with simple types as int, string, DateTime etc.
And this code works now:

```
query = "SELECT COUNT(*) AS value FROM account";
long count = context.ExecuteQueryPrimitive<long>(query).First();
```

One little nuisance of using this method: a column in SQL always should be called 'value'.

---

2.
If table or column name contains '_' separator, DBMetal removes it and makes word-split by letter case (e.g. 'max_date' -> MaxDate). But if you do the same with ExecuteQuery method:

```
query = "SELECT MAX(birth) AS max_birth, COUNT(*) FROM account";
var result2 = context.ExecuteQuery<AccountsInfo>(query).First();
```

you get an error: Invalid column 'max_date'.
The 2nd commit in this pull-request fixes this and such query works fine.
